### PR TITLE
Update support run with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN python -m venv /venv \
     && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install --no-cache-dir -r requirements.txt"
 
 RUN touch /venv/bin/activate
-RUN /venv/bin/python3 -m nltk.downloader stopwords
+RUN /venv/bin/python3 -m nltk.downloader -d /usr/share/nltk_data stopwords
 
 ARG version
 ARG prod
@@ -27,8 +27,8 @@ FROM python:3.7.4-slim
 RUN apt-get update && apt-get install -y libxml2 libgomp1\
     && rm -rf /var/lib/apt/lists/*
 COPY --from=0 /venv /venv
-RUN mkdir /root/nltk_data
-COPY --from=0 /root/nltk_data /root/nltk_data/
+RUN mkdir /usr/share/nltk_data && chmod g+w /usr/share/nltk_data
+COPY --from=0 /usr/share/nltk_data /usr/share/nltk_data/
 
 WORKDIR /backend/
 

--- a/logging.conf
+++ b/logging.conf
@@ -25,7 +25,7 @@ args=(sys.stdout,)
 [handler_fileHandler]
 class=FileHandler
 formatter=myFormatter
-args=("config.log",)
+args=("/tmp/config.log",)
 
 [formatter_myFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
Rootless containers is default in enterprise platform like
OpenShift.

Support rootless with update python nltk module install dir and
grant group access, also update log dir to /tmp.

Signed-off-by: Wayne Sun <gsun@redhat.com>