### PR TITLE
Add manual workflow trigger with image-tag input

### DIFF
--- a/.github/workflows/build-feature-image.yaml
+++ b/.github/workflows/build-feature-image.yaml
@@ -5,6 +5,12 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - 'develop'
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: 'Image tag for the Docker build'
+        required: true
+        default: 'feature'
 
 jobs:
   variables-setup:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow configuration to support manual triggering of feature image builds with a configurable image tag parameter (defaults to `feature`), extending workflow invocation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->