### PR TITLE
EPMRPP-117957 || Use actual build version in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN "${VIRTUAL_ENV}/bin/pip" install --upgrade pip \
 ARG APP_VERSION=""
 ARG RELEASE_MODE=false
 ARG GITHUB_TOKEN
-RUN if [ "$RELEASE_MODE" = "true" ]; then make release v=${APP_VERSION} githubtoken=${GITHUB_TOKEN}; else if [ "${APP_VERSION}" != "" ]; then make build-release v=${APP_VERSION}; fi ; fi
+RUN if [ "$RELEASE_MODE" = "true" ]; then make release v=${APP_VERSION} githubtoken=${GITHUB_TOKEN}; elif [ "${APP_VERSION}" != "" ]; then echo "${APP_VERSION}" > VERSION; fi
 RUN mkdir -p -m 0744 /backend/storage \
     && cp /build/VERSION /backend \
     && cp -r /build/app /backend/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ RUN "${VIRTUAL_ENV}/bin/pip" install --upgrade pip \
 ARG APP_VERSION=""
 ARG RELEASE_MODE=false
 ARG GITHUB_TOKEN
-RUN if [ "$RELEASE_MODE" = "true" ]; then make release v=${APP_VERSION} githubtoken=${GITHUB_TOKEN}; elif [ "${APP_VERSION}" != "" ]; then echo "${APP_VERSION}" > VERSION; fi
+RUN if [ "$RELEASE_MODE" = "true" ]; then \
+        make release v=${APP_VERSION} githubtoken=${GITHUB_TOKEN}; \
+    elif [ "${APP_VERSION}" != "" ]; then \
+        echo "${APP_VERSION}" > VERSION; \
+    fi
 RUN mkdir -p -m 0744 /backend/storage \
     && cp /build/VERSION /backend \
     && cp -r /build/app /backend/ \


### PR DESCRIPTION
Replace make build-release (which silently failed for non-semver versions like develop-436) with a direct write to VERSION.

Example of failing parsing: 
`Evaluating 'parse' option: '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)' does not parse current version 'develop-436'
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container build process to record the specified application version directly for non-release builds.
  - Preserved the existing release build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->