### PR TITLE
EPMRPP-118181 || Fix Make Decision

### DIFF
--- a/app/machine_learning/boosting_featurizer.py
+++ b/app/machine_learning/boosting_featurizer.py
@@ -359,19 +359,21 @@ class BoostingFeaturizer:
         for log, res in all_results:
             test_case_hash_dict = {}
             for r in res["hits"]["hits"]:
-                test_case_hash = r["_source"]["test_case_hash"]
-                if test_case_hash not in test_case_hash_dict:
-                    test_case_hash_dict[test_case_hash] = []
-                test_case_hash_dict[test_case_hash].append(
+                # Group by test case hash and test item so repeated launches of the same test
+                # remain separate suggestion candidates instead of collapsing to a single hit.
+                group_key = (r["_source"]["test_case_hash"], r["_source"]["test_item"])
+                if group_key not in test_case_hash_dict:
+                    test_case_hash_dict[group_key] = []
+                test_case_hash_dict[group_key].append(
                     (r["_id"], int(r["_score"]), datetime.strptime(r["_source"]["start_time"], "%Y-%m-%d %H:%M:%S"))
                 )
             log_ids_to_take = set()
-            for test_case_hash in test_case_hash_dict:
-                test_case_hash_dict[test_case_hash] = sorted(
-                    test_case_hash_dict[test_case_hash], key=lambda x: (x[1], x[2]), reverse=True
+            for group_key in test_case_hash_dict:
+                test_case_hash_dict[group_key] = sorted(
+                    test_case_hash_dict[group_key], key=lambda x: (x[1], x[2]), reverse=True
                 )
                 scores_used = set()
-                for sorted_score in test_case_hash_dict[test_case_hash]:
+                for sorted_score in test_case_hash_dict[group_key]:
                     if sorted_score[1] not in scores_used:
                         log_ids_to_take.add(sorted_score[0])
                         scores_used.add(sorted_score[1])

--- a/app/service/suggest_service.py
+++ b/app/service/suggest_service.py
@@ -371,18 +371,27 @@ class SuggestService(AnalyzerService):
         for log in opensearchpy.helpers.scan(
             self.es_client.es_client, query=self.get_query_for_logs_by_test_item(test_item_id), index=index_name
         ):
-            # clean test item info not to boost by it
-            log["_source"]["test_item"] = 0
-            log["_source"]["test_case_hash"] = 0
-            log["_source"]["unique_id"] = ""
-            log["_source"]["test_item_name"] = ""
             logs.append(log)
         return logs, test_item_id
+
+    def query_logs_for_test_item(self, test_item_info: TestItemInfo, index_name: str) -> list[dict]:
+        logs = []
+        for log in opensearchpy.helpers.scan(
+            self.es_client.es_client,
+            query=self.get_query_for_logs_by_test_item(test_item_info.testItemId),
+            index=index_name,
+        ):
+            logs.append(log)
+        return logs
 
     def prepare_logs_for_suggestions(self, test_item_info: TestItemInfo, index_name: str) -> tuple[list[dict], int]:
         test_item_id_for_suggest = test_item_info.testItemId
         if test_item_info.clusterId != 0:
             prepared_logs, test_item_id_for_suggest = self.query_logs_for_cluster(test_item_info, index_name)
+            logs = self._select_logs_for_suggestion_query(prepared_logs)
+        elif self.es_client.index_exists(index_name):
+            prepared_logs = self.query_logs_for_test_item(test_item_info, index_name)
+            logs = self._select_logs_for_suggestion_query(prepared_logs)
         else:
             unique_logs = text_processing.leave_only_unique_logs(test_item_info.logs)
             prepared_logs = [
@@ -390,8 +399,16 @@ class SuggestService(AnalyzerService):
                 for log in unique_logs
                 if log.logLevel >= utils.ERROR_LOGGING_LEVEL
             ]
-        logs, _ = log_merger.decompose_logs_merged_and_without_duplicates(prepared_logs)
+            logs, _ = log_merger.decompose_logs_merged_and_without_duplicates(prepared_logs)
         return logs, test_item_id_for_suggest
+
+    @staticmethod
+    def _select_logs_for_suggestion_query(prepared_logs: list[dict]) -> list[dict]:
+        """Use indexed non-merged logs as-is; re-decomposing indexed logs degrades ML features."""
+        non_merged_logs = [log for log in prepared_logs if not log["_source"].get("is_merged")]
+        if non_merged_logs:
+            return non_merged_logs
+        return prepared_logs
 
     def suggest_items(self, test_item_info: TestItemInfo) -> list[SuggestAnalysisResult]:
         LOGGER.info(f"Started suggesting for test item with id: {test_item_info.testItemId}")


### PR DESCRIPTION
**Problem:** Make Decision → ML tab was empty even when a previous launch had the same failure already classified.

**Cause:** The suggest flow was not using the logs stored in OpenSearch the way ML expects. It was rebuilding/re-parsing them, which broke ML scoring (~10% instead of ~99%). Also, when several relaunches had the same test, only one launch was kept as a candidate.

What we changed (2 small fixes):

- suggest_service.py — For suggestions, read logs directly from OpenSearch and use them as-is (don’t strip fields, don’t re-decompose). Same source the model was trained on.

- boosting_featurizer.py — When filtering candidates, group by (test_case_hash, test_item) instead of only test_case_hash, so launch 149, 150, 151 stay separate and launch 149 (manually classified) isn’t dropped.

**Result:** Suggest finds the old classified item and shows 99% Analyzer Suggestion instead of nothing.